### PR TITLE
$this->getResponse()->clearHeaders();

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/controllers/AjaxController.php
+++ b/app/code/community/RicardoMartins/PagSeguro/controllers/AjaxController.php
@@ -7,7 +7,7 @@ class RicardoMartins_PagSeguro_AjaxController extends Mage_Core_Controller_Front
     public function getGrandTotalAction()
     {
         $total = Mage::helper('checkout/cart')->getQuote()->getGrandTotal();
-
+        $this->getResponse()->clearHeaders();
         $this->getResponse()->setHeader('Content-type','application/json');
         $this->getResponse()->setBody(json_encode(array('total'=>$total)));
     }


### PR DESCRIPTION
Estava recebendo erro HTTP 500 quando chamava o método setHeader('Content-type','application/json').

Tive que limpar a header antes através do método clearHeaders() para o método setHeader('Content-type','application/json') funcionar e receber HTTP 200.
