### PR TITLE
Evitando Content-types duplicados (firefox fix)

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/controllers/AjaxController.php
+++ b/app/code/community/RicardoMartins/PagSeguro/controllers/AjaxController.php
@@ -8,7 +8,7 @@ class RicardoMartins_PagSeguro_AjaxController extends Mage_Core_Controller_Front
     {
         $total = Mage::helper('checkout/cart')->getQuote()->getGrandTotal();
 
-        $this->getResponse()->setHeader('Content-type','application/json');
+        $this->getResponse()->setHeader('Content-type','application/json', true);
         $this->getResponse()->setBody(json_encode(array('total'=>$total)));
     }
 
@@ -17,7 +17,7 @@ class RicardoMartins_PagSeguro_AjaxController extends Mage_Core_Controller_Front
         $_helper = Mage::helper('ricardomartins_pagseguro');
         $session_id = $_helper->getSessionId();
 
-        $this->getResponse()->setHeader('Content-type','application/json');
+        $this->getResponse()->setHeader('Content-type','application/json', true);
         $this->getResponse()->setBody(json_encode(array('session_id'=>$session_id)));
     }
 }


### PR DESCRIPTION
O código antigo estava adicionando um content-type a mais na resposta, enquanto que no atualizado ele substitui o único content-type. 

O firefox lia só o primeiro que era text. Depois de pegar o grandtotal ele não ia no pagseguro buscar os parcelamentos já que não conseguia fazer parse na resposta do grandtotal. O campo de parcelamento ficava inalterado.

No chrome ele lia os dois content-types e funcionava de qualquer jeito.
