### PR TITLE
Fix credit_card_token error

### DIFF
--- a/app/design/frontend/base/default/template/ricardomartins_pagseguro/form/directpayment.phtml
+++ b/app/design/frontend/base/default/template/ricardomartins_pagseguro/form/directpayment.phtml
@@ -4,7 +4,6 @@ $_helper = Mage::helper('ricardomartins_pagseguro');
 <input type="hidden" name="payment[sender_hash]"/>
 <script type="text/javascript">
     //<![CDATA[
-    PagSeguroDirectPayment.setSessionId('<?php echo $_helper->getSessionId();?>');
     var iid = setInterval(function()
     {
         if(typeof PagSeguroDirectPayment != "undefined" && PagSeguroDirectPayment.ready){

--- a/js/pagseguro/pagseguro.js
+++ b/js/pagseguro/pagseguro.js
@@ -95,8 +95,8 @@ document.observe("dom:loaded", function() {
         var ccCvvElm = $$('input[name="payment[ps_cc_cid]"]').first();
 
         Element.observe(ccNumElm,'keyup',function(e){RMPagSeguro.updateCreditCardToken();});
-        Element.observe(ccExpMoElm,'keyup',function(e){RMPagSeguro.updateCreditCardToken();});
-        Element.observe(ccExpYrElm,'keyup',function(e){RMPagSeguro.updateCreditCardToken();});
+        Element.observe(ccExpMoElm,'change',function(e){RMPagSeguro.updateCreditCardToken();});
+        Element.observe(ccExpYrElm,'change',function(e){RMPagSeguro.updateCreditCardToken();});
         Element.observe(ccCvvElm,'keyup',function(e){RMPagSeguro.updateCreditCardToken();});
     }
 

--- a/js/pagseguro/pagseguro.js
+++ b/js/pagseguro/pagseguro.js
@@ -159,5 +159,6 @@ document.observe("dom:loaded", function() {
             }
         });
     }
+    RMPagSeguro.updateSessionId();
 
 });


### PR DESCRIPTION
Quando o cliente estava no review e voltava para mudar o frete usando o modulo dos correios, quando digitava os dados do cartão novamente aparecia o erro abaixo:

Falha ao obter o token do cartao ou sender_hash. Veja se os dados "sender_hash" e "credit_card_token" foram enviados no formulário. Um problema de JavaScript pode ter ocorrido. Se esta for apenas uma atualização de blocos via ajax nao se preocupe.

Sendo em alguns casos não conseguia passar do pagamento pois aparecia a seguinte mensagem no console do javascript "invalid creditcard data" e para o cliente "dados do cartão inválidos" e com isso não aparecia nem nos logs de erro do magento somente para o cliente, só era possível finalizar a compra caso recarregasse a página completamente.

Foi colocado o carregamento do sessionid do pagseguro em modo global no arquivo pagseguro.js com isso não recarrega toda vez que acessa o bloco de pagamento e não acontece mais esse erro.




