### PR TITLE
Correção erro 53015 sender name invalid value

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
@@ -289,7 +289,7 @@ class RicardoMartins_PagSeguro_Helper_Params extends Mage_Core_Helper_Abstract
      */
     public function removeDuplicatedSpaces($string)
     {
-        return preg_replace('/\s+/', ' ', $string);
+        return preg_replace('/\s+/', ' ', trim($string));
     }
 
     /**


### PR DESCRIPTION
$senderName sempre continuará com 2 espaços se o sobrenome foi digitado com 1 ou mais espaços no início, gerando, erro 53015 sender name invalid value.

É necessário que o método removeDuplicatedSpaces na entrada do argumento da função preg_replace tenha a chamada da função trim.