### PR TITLE
Correção para não duplicar os invoices

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Model/Abstract.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Model/Abstract.php
@@ -80,19 +80,21 @@ class RicardoMartins_PagSeguro_Model_Abstract extends Mage_Payment_Model_Method_
             if ((int)$resultXML->status == 3) { //Quando o pedido foi dado como Pago
                 //cria fatura e envia email (se configurado)
 //                $payment->registerCaptureNotification(floatval($resultXML->grossAmount));
-                $invoice = $order->prepareInvoice();
-                $invoice->register()->pay();
-                $msg = sprintf('Pagamento capturado. Identificador da Transação: %s', (string)$resultXML->code);
-                $invoice->addComment($msg);
-                $invoice->sendEmail(
-                    Mage::getStoreConfigFlag('payment/pagseguro/send_invoice_email'),
-                    'Pagamento recebido com sucesso.'
-                );
-                Mage::getModel('core/resource_transaction')
-                    ->addObject($invoice)
-                    ->addObject($invoice->getOrder())
-                    ->save();
-                $order->addStatusHistoryComment(sprintf('Fatura #%s criada com sucesso.', $invoice->getIncrementId()));
+                if(!$order->hasInvoices()){
+                    $invoice = $order->prepareInvoice();
+                    $invoice->register()->pay();
+                    $msg = sprintf('Pagamento capturado. Identificador da Transação: %s', (string)$resultXML->code);
+                    $invoice->addComment($msg);
+                    $invoice->sendEmail(
+                        Mage::getStoreConfigFlag('payment/pagseguro/send_invoice_email'),
+                        'Pagamento recebido com sucesso.'
+                    );
+                    Mage::getModel('core/resource_transaction')
+                        ->addObject($invoice)
+                        ->addObject($invoice->getOrder())
+                        ->save();
+                    $order->addStatusHistoryComment(sprintf('Fatura #%s criada com sucesso.', $invoice->getIncrementId()));
+                }
             }
 
             $payment->save();


### PR DESCRIPTION
Por algum motivo, o PagSeguro acaba enviando várias vezes uma mesma notificação de pagamento aprovado. A cada nova notificação recebida, o módulo gerava um novo invoice pra mesma order (mesmo que ela já tenha um) com valores zerados.