### PR TITLE
Melhoria nas notificações

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
@@ -31,6 +31,7 @@ class RicardoMartins_PagSeguro_Helper_Data extends Mage_Core_Helper_Abstract
     const XML_PATH_PAYMENT_PAGSEGUROPRO_BOLETO_ACTIVE   = 'payment/pagseguropro_boleto/active';
     const XML_PATH_PAYMENT_PAGSEGURO_KEY                = 'payment/pagseguropro/key';
     const XML_PATH_PAYMENT_PAGSEGURO_CC_FORCE_INSTALLMENTS = 'payment/rm_pagseguro_cc/force_installments_selection';
+    const XML_PATH_PAYMENT_PAGSEGURO_CC_INSTALLMENT_LIMIT  = 'payment/rm_pagseguro_cc/installment_limit';
 
     /**
      * Returns session ID from PagSeguro that will be used on JavaScript methods.
@@ -311,7 +312,9 @@ class RicardoMartins_PagSeguro_Helper_Data extends Mage_Core_Helper_Abstract
             'is_admin' => Mage::app()->getStore()->isAdmin(),
             'show_total' => Mage::getStoreConfigFlag(self::XML_PATH_PAYMENT_PAGSEGURO_CC_SHOW_TOTAL),
             'force_installments_selection' =>
-                Mage::getStoreConfigFlag(self::XML_PATH_PAYMENT_PAGSEGURO_CC_FORCE_INSTALLMENTS)
+                Mage::getStoreConfigFlag(self::XML_PATH_PAYMENT_PAGSEGURO_CC_FORCE_INSTALLMENTS),
+            'installment_limit' =>
+                (int)Mage::getStoreConfigFlag(self::XML_PATH_PAYMENT_PAGSEGURO_CC_INSTALLMENT_LIMIT)
         );
         return json_encode($config);
     }

--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
@@ -408,7 +408,7 @@ class RicardoMartins_PagSeguro_Helper_Params extends Mage_Core_Helper_Abstract
      */
     private function _getCustomerCcDobValue(Mage_Customer_Model_Customer $customer, $payment)
     {
-        $ccDobAttribute = Mage::getStoreConfig('payment/pagseguro_cc/owner_dob_attribute');
+        $ccDobAttribute = Mage::getStoreConfig('payment/rm_pagseguro_cc/owner_dob_attribute');
 
         if (empty($ccDobAttribute)) { //when asked with payment data
             if (isset($payment['additional_information']['credit_card_owner_birthdate'])) {

--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
@@ -400,7 +400,7 @@ class RicardoMartins_PagSeguro_Helper_Params extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * Returns customer's date of birthday, based on your module configuration
+     * Returns customer's date of birthday, based on your module configuration or return a default date
      * @param Mage_Customer_Model_Customer $customer
      * @param                              $payment
      *
@@ -416,7 +416,12 @@ class RicardoMartins_PagSeguro_Helper_Params extends Mage_Core_Helper_Abstract
             }
         }
 
-        $dob = $customer->getResource()->getAttribute($ccDobAttribute)->getFrontend()->getValue($customer);
+        $attribute = $customer->getResource()->getAttribute($ccDobAttribute);
+        if (!$attribute) {
+            return '01/01/1970';
+        }
+
+        $dob = $attribute->getFrontend()->getValue($customer);
 
 
         return date('d/m/Y', strtotime($dob));

--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
@@ -416,11 +416,17 @@ class RicardoMartins_PagSeguro_Helper_Params extends Mage_Core_Helper_Abstract
             }
         }
 
+        //try to get from payment info
+        $dob = $payment->getOrder()->getData('customer_' . $ccDobAttribute);
+        if (!empty($dob)) {
+            return date('d/m/Y', strtotime($dob));
+        }
+
+        //try to get from customer
         $attribute = $customer->getResource()->getAttribute($ccDobAttribute);
         if (!$attribute) {
             return '01/01/1970';
         }
-
         $dob = $attribute->getFrontend()->getValue($customer);
 
 

--- a/app/code/community/RicardoMartins/PagSeguro/Model/Healthcheck.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Model/Healthcheck.php
@@ -1,0 +1,75 @@
+<?php
+class RicardoMartins_PagSeguro_Model_Healthcheck extends Mage_Core_Model_Abstract
+{
+    protected $_errors = array();
+
+    public function check(Varien_Event_Observer $observer)
+    {
+
+        $this->_checkSessionId();
+        $this->basicCheck($observer);
+    }
+
+    public function basicCheck(Varien_Event_Observer $observer)
+    {
+        $this->_checkToken();
+        $this->_checkSandbox();
+        $this->_checkVersions();
+        $this->_processCheckResults();
+    }
+
+    protected function _processCheckResults()
+    {
+        if (count($this->_errors) > 0) {
+            $msg = 'Os seguintes erros nas configurações do PagSeguro foram encontrados: ';
+            $msg .= '<br/>- '. implode("<br/>- ", $this->_errors);
+            Mage::getSingleton('adminhtml/session')->addError($msg);
+        }
+    }
+
+    protected function _checkToken()
+    {
+        $token = Mage::helper('ricardomartins_pagseguro')->getToken();
+
+        if(strlen($token)!=32)
+            $this->_errors[] = 'O token PagSeguro digitado não é válido.';
+    }
+
+    protected function _checkSandbox()
+    {
+        $helper = Mage::helper('ricardomartins_pagseguro');
+        $keyType = $helper->getLicenseType();
+
+        if (Mage::getStoreConfigFlag('payment/rm_pagseguro/sandbox') && $keyType == 'app') {
+            $this->_errors[] = 'Ambiente de testes (sandbox) não disponível no modelo de aplicação.';
+        }
+    }
+
+    protected function _checkVersions()
+    {
+        $mainModuleVersion = (string)Mage::getConfig()->getModuleConfig('RicardoMartins_PagSeguro')->version;
+
+        if (Mage::getConfig()->getModuleConfig('RicardoMartins_PagSeguroPro')) {
+            $proVersion = (string)Mage::getConfig()->getModuleConfig('RicardoMartins_PagSeguroPro')->version;
+        }
+
+        if (!isset($proVersion) || empty($proVersion)) {
+            return;
+        }
+
+       $majorVersionNumberPro = substr($proVersion, 0, 1);
+       $majorVersionNumberMain = substr($mainModuleVersion, 0, 1);
+       if ($majorVersionNumberPro != $majorVersionNumberMain) {
+           $this->_errors[] = 'Módulo PRO e módulo principal são de versões incompatíveis. Atualize ambos os mdulos.';
+       }
+    }
+
+    protected function _checkSessionId()
+    {
+        $helper = Mage::helper('ricardomartins_pagseguro');
+
+        if (!$helper->getSessionId()) {
+            $this->_errors[] = 'Não foi possível obter o sessionId. Verifique e-mail e chave digitados.';
+        }
+    }
+}

--- a/app/code/community/RicardoMartins/PagSeguro/Model/Source/Ccinstallments.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Model/Source/Ccinstallments.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * PagSeguro Transparente Magento
+ *
+ * @category    RicardoMartins
+ * @package     RicardoMartins_PagSeguro
+ * @author      Ricardo Martins
+ * @copyright   Copyright (c) 2017 Ricardo Martins (http://r-martins.github.io/PagSeguro-Magento-Transparente/)
+ * @license     https://opensource.org/licenses/MIT MIT License
+ */
+class RicardoMartins_PagSeguro_Model_Source_Ccinstallments
+{
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        $options = array();
+        $options[] = array('value'=>'','label'=>'Usar configurações definidas na conta PagSeguro (recomendável)');
+        $options[] = array('value'=>'1','label'=>'Apenas pagamentos à vista (1x)');
+
+        for ($x=2; $x <= 18; $x++) {
+            $options[] = array('value'=>$x,'label'=>$x . ' vezes');
+        }
+
+        return $options;
+    }
+}

--- a/app/code/community/RicardoMartins/PagSeguro/controllers/NotificationController.php
+++ b/app/code/community/RicardoMartins/PagSeguro/controllers/NotificationController.php
@@ -22,6 +22,24 @@ class RicardoMartins_PagSeguro_NotificationController extends Mage_Core_Controll
         if ($helper->isSandbox()) {
             $this->getResponse()->setHeader('access-control-allow-origin', 'https://sandbox.pagseguro.uol.com.br');
         }
+
+        if ( $this->getRequest()->getPost('notificationCode', false) == false) {
+            $this->getResponse()->setHttpResponseCode(422);
+            $this->loadLayout();
+            $this->renderLayout();
+            return;
+        }
+        $notificationCode = $this->getRequest()->getPost('notificationCode');
+
+        //Workaround for duplicated PagSeguro notifications (Issue #215)
+        $exists = Mage::app()->getCache()->load($notificationCode);
+        if($exists){
+            $this->getResponse()->setHttpResponseCode(400);
+            $this->getResponse()->setBody('Notificação já enviada a menos de 1 minuto.');
+            return;
+        }
+        Mage::app()->getCache()->save('in_progress', $notificationCode, array('pagseguro_notification'), 60);
+
         /** @var RicardoMartins_PagSeguro_Model_Abstract $model */
         Mage::helper('ricardomartins_pagseguro')
             ->writeLog(
@@ -29,12 +47,14 @@ class RicardoMartins_PagSeguro_NotificationController extends Mage_Core_Controll
                 . var_export($this->getRequest()->getParams(), true)
             );
         $model =  Mage::getModel('ricardomartins_pagseguro/abstract');
-        $response = $model->getNotificationStatus($this->getRequest()->getPost('notificationCode'));
+        $response = $model->getNotificationStatus($notificationCode);
         if (false === $response) {
             Mage::throwException('Falha ao processar retorno XML do PagSeguro.');
         }
         $model->proccessNotificatonResult($response);
-
+        if (isset($response->reference)) {
+            $this->getResponse()->setBody('Notificação recebida para o pedido ' . (string)$response->reference);
+        }
 
     }
 }

--- a/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
+++ b/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <RicardoMartins_PagSeguro>
-            <version>3.3.0</version>
+            <version>3.4.0</version>
         </RicardoMartins_PagSeguro>
     </modules>
     <global>
@@ -59,6 +59,13 @@
                 </observers>
             </core_block_abstract_to_html_after>
         </events>
+        <layout>
+            <updates>
+                <ricardomartins_pagseguro>
+                    <file>ricardomartins_pagseguro.xml</file>
+                </ricardomartins_pagseguro>
+            </updates>
+        </layout>
     </frontend>
     <adminhtml>
         <layout>
@@ -68,6 +75,26 @@
                 </ricardomartins_pagseguro>
             </updates>
         </layout>
+        <events>
+            <admin_session_user_login_success>
+                <observers>
+                    <ricardomartins_pagseguro_healthcheck>
+                        <type>singleton</type>
+                        <class>ricardomartins_pagseguro/healthcheck</class>
+                        <method>basicCheck</method>
+                    </ricardomartins_pagseguro_healthcheck>
+                </observers>
+            </admin_session_user_login_success>
+            <admin_system_config_changed_section_payment>
+                <observers>
+                    <ricardomartins_pagseguro_healthcheck>
+                        <type>singleton</type>
+                        <class>ricardomartins_pagseguro/healthcheck</class>
+                        <method>check</method>
+                    </ricardomartins_pagseguro_healthcheck>
+                </observers>
+            </admin_system_config_changed_section_payment>
+    </events>
     </adminhtml>
     <default>
         <payment>

--- a/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
+++ b/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <RicardoMartins_PagSeguro>
-            <version>3.2.3</version>
+            <version>3.2.4</version>
         </RicardoMartins_PagSeguro>
     </modules>
     <global>

--- a/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
+++ b/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <RicardoMartins_PagSeguro>
-            <version>3.2.5</version>
+            <version>3.2.6</version>
         </RicardoMartins_PagSeguro>
     </modules>
     <global>

--- a/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
+++ b/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <RicardoMartins_PagSeguro>
-            <version>3.2.6</version>
+            <version>3.3.0</version>
         </RicardoMartins_PagSeguro>
     </modules>
     <global>

--- a/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
+++ b/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <RicardoMartins_PagSeguro>
-            <version>3.2.4</version>
+            <version>3.2.5</version>
         </RicardoMartins_PagSeguro>
     </modules>
     <global>

--- a/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
+++ b/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <RicardoMartins_PagSeguro>
-            <version>3.2.2</version>
+            <version>3.2.3</version>
         </RicardoMartins_PagSeguro>
     </modules>
     <global>

--- a/app/code/community/RicardoMartins/PagSeguro/etc/system.xml
+++ b/app/code/community/RicardoMartins/PagSeguro/etc/system.xml
@@ -323,6 +323,16 @@
                             <show_in_store>1</show_in_store>
                             <comment><![CDATA[Quando habilitado, forçará o cliente a selecionar o valor de parcelas ao invés de deixar pagamento a vista pre-selecionado.]]></comment>
                         </force_installments_selection>
+                        <installment_limit>
+                            <label>Limitar parcelas</label>
+                            <frontend_type>select</frontend_type>
+                            <sort_order>90</sort_order>
+                            <source_model>ricardomartins_pagseguro/source_ccinstallments</source_model>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[Limita o número de parcelas. A configuração de juros é sempre feita no seu painel PagSeguro.]]></comment>
+                        </installment_limit>
                     </fields>
                 </rm_pagseguro_cc>
             </groups>

--- a/app/design/frontend/base/default/layout/ricardomartins_pagseguro.xml
+++ b/app/design/frontend/base/default/layout/ricardomartins_pagseguro.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<layout>
+    <ricardomartins_pagseguro_notification_index>
+        <reference name="content">
+            <block name="ricardomartins.pagseguro.notification" type="core/template" template="ricardomartins_pagseguro/notification.phtml" after="-"/>
+        </reference>
+    </ricardomartins_pagseguro_notification_index>
+</layout>

--- a/app/design/frontend/base/default/template/ricardomartins_pagseguro/notification.phtml
+++ b/app/design/frontend/base/default/template/ricardomartins_pagseguro/notification.phtml
@@ -1,0 +1,8 @@
+<h1>Requisição inválida</h1>
+<h2>Esta página espera receber o parâmetro <em>notificationCode</em> via POST.</h2>
+<p>Se desejar realizar um teste de notificação, cole o notificationCode da transação e submeta novamente.</p>
+<p>Para mais informações consulte <a href="https://pagsegurotransparente.zendesk.com/hc/pt-br/articles/209089326-Configurei-o-retorno-autom%C3%A1tico-mas-parece-n%C3%A3o-funcionar-">este link</a>.</p>
+<form action="" method="post">
+    <input type="text" name="notificationCode" required/>
+    <input type="submit" value="Enviar"/>
+</form>

--- a/js/pagseguro/pagseguro.js
+++ b/js/pagseguro/pagseguro.js
@@ -2,7 +2,7 @@
  * PagSeguro Transparente para Magento
  * @author Ricardo Martins <ricardo@ricardomartins.net.br>
  * @link https://github.com/r-martins/PagSeguro-Magento-Transparente
- * @version 3.2.3
+ * @version 3.3.0
  */
 
 RMPagSeguro = Class.create({
@@ -104,6 +104,7 @@ RMPagSeguro = Class.create({
                     parcelsDrop.add(option);
                 }
 
+                var installment_limit = RMPagSeguroObj.config.installment_limit;
                 for(var x=0; x < b.length; x++){
                     var option = document.createElement('option');
                     option.text = b[x].quantity + "x de R$" + b[x].installmentAmount.toFixed(2).toString().replace('.',',');
@@ -113,6 +114,9 @@ RMPagSeguro = Class.create({
                     }
                     option.selected = (b[x].quantity == selectedInstallment);
                     option.value = b[x].quantity + "|" + b[x].installmentAmount;
+                    if (installment_limit != 0 && installment_limit <= x) {
+                        break;
+                    }
                     parcelsDrop.add(option);
                 }
 //                       console.log(b[0].quantity);

--- a/js/pagseguro/pagseguro.js
+++ b/js/pagseguro/pagseguro.js
@@ -2,7 +2,7 @@
  * PagSeguro Transparente para Magento
  * @author Ricardo Martins <ricardo@ricardomartins.net.br>
  * @link https://github.com/r-martins/PagSeguro-Magento-Transparente
- * @version 3.2.2
+ * @version 3.2.3
  */
 
 RMPagSeguro = Class.create({

--- a/modman
+++ b/modman
@@ -6,3 +6,4 @@ app/etc/modules/RicardoMartins_PagSeguro.xml app/etc/modules/RicardoMartins_PagS
 app/locale/pt_BR/RicardoMartins_PagSeguro.csv app/locale/pt_BR/RicardoMartins_PagSeguro.csv
 js/pagseguro/pagseguro.js js/pagseguro/pagseguro.js
 skin/frontend/base/default/pagseguro/selo/* skin/frontend/base/default/pagseguro/selo/
+app/design/frontend/base/default/layout/ricardomartins_pagseguro.xml app/design/frontend/base/default/layout/ricardomartins_pagseguro.xml


### PR DESCRIPTION
Seria de grande importância se na listagem dos pedidos pudéssemos selecionar todos (ou alguns pedidos) e ir em AÇÕES->VERIFICAR STATUS DO PEDIDO, visto que ocorre com frequência as tentativas do pagseguro enviar as notificações para o site e muitas vezes o status não muda no site.

Como vc ja fez a a pagina de verificar a notificação, e quando solicitamos via post nesta página funciona normalmente, talvez fazer isso ficar mais dinamico podendo atualizar mais pedidos de uma vez seja uma mão na roda.
