### PR TITLE
Correção do bug associado à chave da aplicação em Sandbox

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
@@ -50,9 +50,8 @@ class RicardoMartins_PagSeguro_Helper_Data extends Mage_Core_Helper_Abstract
         if ($fromCache = $this->getSavedSessionId()) {
             return $fromCache;
         }
-
+        
         $useApp = $this->getLicenseType() == 'app';
-
         $url = $this->getWsUrl('sessions', $useApp);
 
         $ch = curl_init($url);
@@ -274,6 +273,11 @@ class RicardoMartins_PagSeguro_Helper_Data extends Mage_Core_Helper_Abstract
     public function getLicenseType()
     {
         $key = Mage::getStoreConfig(self::XML_PATH_PAYMENT_PAGSEGURO_KEY);
+
+        if($this->isSandbox()) {
+            $key = Mage::getStoreConfig(self::XML_PATH_PAYMENT_PAGSEGURO_SANDBOX_APPKEY);
+        }
+
         if (!$key || strlen($key) <= 6) {
             return '';
         }

--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
@@ -50,7 +50,7 @@ class RicardoMartins_PagSeguro_Helper_Data extends Mage_Core_Helper_Abstract
         if ($fromCache = $this->getSavedSessionId()) {
             return $fromCache;
         }
-        
+
         $useApp = $this->getLicenseType() == 'app';
         $url = $this->getWsUrl('sessions', $useApp);
 


### PR DESCRIPTION
Quando a configuração estava habilitada para Sandbox, o flag que determinava o tipo de aplicação considerava a chave a ser utilizada em produção - no lugar da destinada ao Sandbox.

O devido tratamento foi adicionado para corrigir o problema.