### PR TITLE
Conferência de índice em vetor, antes de utilizá-lo

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Model/Abstract.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Model/Abstract.php
@@ -418,7 +418,9 @@ class RicardoMartins_PagSeguro_Model_Abstract extends Mage_Payment_Model_Method_
             )
         );
         $params = $paramsObj->getParams();
-        if (strpos($params['senderEmail'], '@sandbox.pagseguro') !== false && !$helper->isSandbox())
+        $senderEmail = isset($params['senderEmail']) ? $params['senderEmail'] : "";
+
+        if (strpos($senderEmail, '@sandbox.pagseguro') !== false && !$helper->isSandbox())
         {
             Mage::throwException('E-mail @sandbox.pagseguro não deve ser usado em produção');
         }


### PR DESCRIPTION
Na classe RicardoMartins_PagSeguro_Model_Abstract foi inserido um tratamento para evitar o alerta de "undefined index" na linha 421 - conferência se o e-mail do cliente é testes e o ambiente não é Sandbox.