### PR TITLE
Remoção do uso da classe Zend_Serializer

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
@@ -694,7 +694,6 @@ class RicardoMartins_PagSeguro_Helper_Params extends Mage_Core_Helper_Abstract
      *
      * @return bool|string
      * @throws Mage_Core_Model_Store_Exception
-     * @throws Zend_Serializer_Exception
      */
     public function getPaymentHash($param=null)
     {
@@ -708,7 +707,7 @@ class RicardoMartins_PagSeguro_Helper_Params extends Mage_Core_Helper_Abstract
            return false;
         }
 
-        $registry = Zend_Serializer::unserialize($registry);
+        $registry = unserialize($registry);
 
         if (null === $param) {
             return $registry;

--- a/app/code/community/RicardoMartins/PagSeguro/Model/Recurring.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Model/Recurring.php
@@ -75,7 +75,7 @@ class RicardoMartins_PagSeguro_Model_Recurring extends RicardoMartins_PagSeguro_
     {
         //general status (ACTIVE, EXPIRED, etc)
         $additionalInfo = $profile->getAdditionalInfo();
-        $additionalInfo = is_string($additionalInfo) ? Zend_Serializer::unserialize($profile->getAdditionalInfo())
+        $additionalInfo = is_string($additionalInfo) ? unserialize($profile->getAdditionalInfo())
             : $additionalInfo;
         $isSandbox = (isset($additionalInfo['isSandbox']) && $additionalInfo['isSandbox']);
         $currentStatus = $this->getPreApprovalDetails($profile->getReferenceId(), $isSandbox);

--- a/app/code/community/RicardoMartins/PagSeguro/controllers/AjaxController.php
+++ b/app/code/community/RicardoMartins/PagSeguro/controllers/AjaxController.php
@@ -52,9 +52,9 @@ class RicardoMartins_PagSeguro_AjaxController extends Mage_Core_Controller_Front
         $session = 'checkout/session';
         if ($isAdmin) {
             $session = 'core/cookie';
-            Mage::getSingleton($session)->set('PsPayment', Zend_Serializer::serialize($paymentPost));
+            Mage::getSingleton($session)->set('PsPayment', serialize($paymentPost));
         } else {
-            Mage::getSingleton($session)->setData('PsPayment', Zend_Serializer::serialize($paymentPost));
+            Mage::getSingleton($session)->setData('PsPayment', serialize($paymentPost));
         }
 
         $this->getResponse()->setHttpResponseCode(200);


### PR DESCRIPTION
... e substituição pela função padrão da linguagem PHP.

O problema com a Zend_Serializer não funcionar com a compilão ativada parece não ter recebido muita importância na Magento. Ainda, outros player's adotaram a mesma postura em remover a função Zend_Serializer, como por exemplo a Mailchimp,

Por fim, a serialização é um conceito implementado pela maioria das linguagens e, portanto, o PHP o suporta desde versões bem antigas e deve continuar implementando em versões futuras.