### PR TITLE
Aviso de consulta de parcelas no resumo do cartão

### DIFF
--- a/js/pagseguro/pagseguro.js
+++ b/js/pagseguro/pagseguro.js
@@ -1313,6 +1313,7 @@ RMPagSeguro_Multicc_CardForm = Class.create
 
         this._debug("Solicitando parcelas para o valor de " + this.getCardData("total").toFixed(2));
         this._clearInstallmentsOptions("Consultando demais parcelas na PagSeguro...");
+        this.setCardMetadata("installments_description", "Buscando parcelas na PagSeguro...");
         //this._insert1xInstallmentsOption();
 
         var params =
@@ -1486,6 +1487,7 @@ RMPagSeguro_Multicc_CardForm = Class.create
     {
         this._clearInstallmentsOptions("Falha ao obter demais parcelas junto ao pagseguro");
         this._insert1xInstallmentsOption();
+        this._updateInstallmentsMetadata();
         
         console.error('Somente uma parcela será exibida. Erro ao obter parcelas junto ao PagSeguro:');
         console.error(response);


### PR DESCRIPTION
Ao alterar o total do segundo cartão, os valores das parcelas do primeiro cartão são buscados na PagSeguro. 

Com a modificação proposta neste pull request, no momento em que a consulta é iniciada, a mensagem "Buscando parcelas na PagSeguro..." é mostrada no lugar do valor das parcelas no resumo do primeiro cartão. Quando a consulta retorna, o valor é atualizado no resumo do cartão 1, evitando divergência entre valores mostrados.

![print](https://user-images.githubusercontent.com/2099888/113796119-e0bc8480-9724-11eb-8669-7ae669d336d7.jpg)
