### PR TITLE
Utilização da chave de aplicação de Sandbox para testes

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
@@ -52,10 +52,7 @@ class RicardoMartins_PagSeguro_Helper_Data extends Mage_Core_Helper_Abstract
             return $fromCache;
         }
 
-        $useApp = $this->getLicenseType() == 'app'
-            && !empty(
-                Mage::getStoreConfig(self::XML_PATH_PAYMENT_PAGSEGURO_KEY)
-            );
+        $useApp = $this->getLicenseType() == 'app';
         $url = $this->getWsUrl('sessions', $useApp);
 
         $ch = curl_init($url);
@@ -283,6 +280,10 @@ class RicardoMartins_PagSeguro_Helper_Data extends Mage_Core_Helper_Abstract
     public function getLicenseType()
     {
         $key = Mage::getStoreConfig(self::XML_PATH_PAYMENT_PAGSEGURO_KEY);
+
+        if ($this->isSandbox()) {
+            $key = Mage::getStoreConfig(self::XML_PATH_PAYMENT_PAGSEGURO_SANDBOX_APPKEY);
+        }
 
         if (!$key || strlen($key) <= 6) {
             return '';


### PR DESCRIPTION
Anteriormente, ambas as chaves deveriam ser preenchidas para que o ambiente Sandbox permitisse testes no modo 'Aplicação'.