### PR TITLE
Correção de bug na informação do pedido na administração

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Block/Form/Info/Cc.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Block/Form/Info/Cc.php
@@ -166,7 +166,8 @@ class RicardoMartins_PagSeguro_Block_Form_Info_Cc extends Mage_Payment_Block_Inf
      */
     protected function _useNewInfoFormat()
     {
-        return $this->getInfo()->getAdditionalInformation("cc1") != null;
+        $additionalInfo = $this->getInfo()->getAdditionalInformation();
+        return isset($additionalInfo["use_two_cards"]);
     }
 
     /**


### PR DESCRIPTION
A conferência que determina qual formulário utilizar na página do pedido (info) foi alterada, para melhorar a compatibilidade com os pedidos sem a funcionalidade de multi cartão de crédito.