### PR TITLE
Solicita CPF do titular do cartão no formulário quando cliente é PJ

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Block/Form/Cc/CardFields.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Block/Form/Cc/CardFields.php
@@ -83,6 +83,41 @@ class RicardoMartins_PagSeguro_Block_Form_Cc_CardFields extends Mage_Core_Block_
     }
 
     /**
+     * Checks if must show owner document field on form
+     * @return bool
+     */
+    public function isCpfVisible()
+    {
+        $configIsVisible = $this->helper("ricardomartins_pagseguro")->isCpfVisible();
+
+        if (!$configIsVisible) {
+            $digits = new Zend_Filter_Digits();
+            $cpf = $digits->filter($this->getCurrentCustomerDocument());
+
+            if (strlen($cpf) > 11) {
+                return true;
+            }
+        }
+
+        return $configIsVisible;
+    }
+
+    /**
+     * Retrieves the current owner document on checkout
+     * @return string
+     */
+    protected function getCurrentCustomerDocument()
+    {
+        $cpfAttConf = Mage::getStoreConfig('payment/rm_pagseguro/customer_cpf_attribute');
+
+        if (!$cpfAttConf) {
+            return $this->getInfoData("owner_document");
+        }
+        
+        return $this->getParentFormBlock()->getCurrentCustomerDocument();
+    }
+
+    /**
      * Get payment method code from parent block
      * @return string
      */

--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
@@ -581,7 +581,7 @@ class RicardoMartins_PagSeguro_Helper_Params extends Mage_Core_Helper_Abstract
      *
      * @return mixed
      */
-    private function _getCustomerCpfValue($order, $payment)
+    protected function _getCustomerCpfValue($order, $payment)
     {
         $customerCpfAttribute = Mage::getStoreConfig('payment/rm_pagseguro/customer_cpf_attribute');
 
@@ -595,23 +595,20 @@ class RicardoMartins_PagSeguro_Helper_Params extends Mage_Core_Helper_Abstract
         $attrName = end($cpfAttributeCnf);
         $cpf = '';
         if ($entity && $attrName) {
-            if (!$order->getCustomerIsGuest()) {
-                $address = ($entity == 'customer') ? $order->getShippingAddress() : $order->getBillingAddress();
-                $cpf = $address->getData($attrName);
+            $address = ($entity == 'customer') ? $order->getShippingAddress() : $order->getBillingAddress();
+            $cpf = $address->getData($attrName);
 
-                //if fail,try to get cpf from customer entity
-                if (!$cpf) {
-                    $customer = $order->getCustomer();
-                    $cpf = $customer->getData($attrName);
-                }
+            //if fail,try to get cpf from customer entity
+            if (!$cpf && !$order->getCustomerIsGuest()) {
+                $customer = $order->getCustomer();
+                $cpf = $customer->getData($attrName);
             }
 
             //for guest orders...
-            if (!$cpf && $order->getCustomerIsGuest()) {
+            if (!$cpf) {
                 $cpf = $order->getData($entity . '_' . $attrName);
             }
         }
-
 
         $cpfObj = new Varien_Object(array('cpf'=>$cpf));
 

--- a/app/code/community/RicardoMartins/PagSeguro/Model/Payment/Cc.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Model/Payment/Cc.php
@@ -110,7 +110,7 @@ class RicardoMartins_PagSeguro_Model_Payment_Cc extends RicardoMartins_PagSeguro
         $info->setAdditionalInformation('credit_card_owner', $data->getPsCcOwner());
 
         //cpf
-        if (Mage::helper('ricardomartins_pagseguro')->isCpfVisible()) {
+        if ($data->getData($this->getCode() . '_cpf')) {
             $info->setAdditionalInformation($this->getCode() . '_cpf', $data->getData($this->getCode() . '_cpf'));
         }
 

--- a/app/design/frontend/base/default/template/ricardomartins_pagseguro/form/cc.phtml
+++ b/app/design/frontend/base/default/template/ricardomartins_pagseguro/form/cc.phtml
@@ -87,7 +87,7 @@ $multiCcEnabled = Mage::helper('ricardomartins_pagseguro')->isMultiCcEnabled();
             <?php echo $_dob->toHtml() ?>
         </li>
     <?php endif ?>
-    <?php if(Mage::helper('ricardomartins_pagseguro')->isCpfVisible()):?>
+    <?php if($this->isCpfVisible()):?>
         <li id="<?php echo $_code ?>_cpf_div">
             <label for="<?php echo $_code ?>_cpf" class="required"><em>*</em><?php echo $this->__('Credit Card Owner\'s CPF') ?></label>
             <div class="input-box">

--- a/app/design/frontend/base/default/template/ricardomartins_pagseguro/form/cc/card-fields.phtml
+++ b/app/design/frontend/base/default/template/ricardomartins_pagseguro/form/cc/card-fields.phtml
@@ -113,7 +113,7 @@ $_helper = $this->helper('ricardomartins_pagseguro');
     <?php echo $this->getDobBlockHtml() ?>
 </li>
 <?php endif ?>
-<?php if($_helper->isCpfVisible()):?>
+<?php if($this->isCpfVisible()):?>
 <li data-field-profile="default" data-card-index="<?php echo $this->getCardIndex() ?>" style="display: none;">
     <label for="<?php echo $this->getElementId("owner_document") ?>" class="required"><em>*</em><?php echo $this->__('Credit Card Owner\'s CPF') ?></label>
     <div class="input-box">


### PR DESCRIPTION
Formulário de cartão de crédito solicita CPF do titular mesmo quando a configuração indica que o documento deve ser obtido no cadastro do cliente, para os casos em que o CNPJ for disponilizado ao invés do CPF.