### PR TITLE
Versão artificial do switch de compra com dois cartões

### DIFF
--- a/app/design/frontend/base/default/template/ricardomartins_pagseguro/form/multi-cc.phtml
+++ b/app/design/frontend/base/default/template/ricardomartins_pagseguro/form/multi-cc.phtml
@@ -8,10 +8,10 @@ $_iwdEnabled = $_helper->isIwdEnabled();
 <ul class="form-list rm-pagseguro-payment-form" id="payment_form_<?php echo $_code ?>" style="<?php echo (!$_iwdEnabled) ? 'display:none;' : ''; ?>">
     <li class="multi-cc-switch-box">
         <label class="switch">
-            <input type="checkbox" name="payment[use_two_cards]" id="<?php echo $_code; ?>_switch_use_two_cards" class="validate-rm-pagseguro-multi-cc-enabled" />
             <span class="slider round"></span>
         </label>
-        <label for="<?php echo $_code; ?>_switch_use_two_cards"><?php echo __('Pay with 2 cards')?></label>
+        <label class="switch-label"><?php echo __('Pay with 2 cards') ?></label>
+        <input type="checkbox" name="payment[use_two_cards]" id="<?php echo $_code; ?>_switch_use_two_cards" class="validate-rm-pagseguro-multi-cc-enabled" />
     </li>
 
     <!-- first card form -->

--- a/js/pagseguro/pagseguro.js
+++ b/js/pagseguro/pagseguro.js
@@ -507,8 +507,18 @@ RMPagSeguro_Multicc_Control = Class.create
             checkbox.checked 
                 ? this._enableMultiCc() 
                 : this._disableMultiCc();
+            checkbox.siblings("label.switch").each(function(element) {
+                element.toggleClassName("on");
+            });
             
         }).bind(this));
+
+        // swtich labels click event
+        multiCcSwitch.siblings("label").each(function(element) {
+            element.observe("click", function() {
+                multiCcSwitch.click();
+            })
+        });
 
         // {go to card 2 form} button
         this._getGoToCard2FormButton().observe('click', (function()

--- a/skin/frontend/base/default/pagseguro/rm_pagseguro.css
+++ b/skin/frontend/base/default/pagseguro/rm_pagseguro.css
@@ -33,7 +33,7 @@
     height: 15px;
     margin-right: 10px;
 }
-.rm-pagseguro-payment-form .multi-cc-switch-box .switch input
+.rm-pagseguro-payment-form .multi-cc-switch-box input
 {
     opacity: 0;
     width: 0;
@@ -63,15 +63,11 @@
     -webkit-transition: .1s;
     transition: .1s;
 }
-.rm-pagseguro-payment-form .multi-cc-switch-box input:checked + .slider
+.rm-pagseguro-payment-form .multi-cc-switch-box .switch.on .slider
 {
     background-color: #89c75d;
 }
-.rm-pagseguro-payment-form .multi-cc-switch-box input:focus + .slider
-{
-    box-shadow: 0 0 1px #89C75D;
-}
-.rm-pagseguro-payment-form .multi-cc-switch-box input:checked + .slider:before
+.rm-pagseguro-payment-form .multi-cc-switch-box .switch.on .slider:before
 {
     -webkit-transform: translateX(14px);
     -ms-transform: translateX(14px);
@@ -84,6 +80,10 @@
 .rm-pagseguro-payment-form .multi-cc-switch-box .slider.round:before
 {
     border-radius: 50%;
+}
+.rm-pagseguro-payment-form .multi-cc-switch-box .switch-label
+{
+    cursor: pointer;
 }
 
 /* multi credit card progress bar */


### PR DESCRIPTION
Originalmente, o módulo utiliza CSS e eventos nativos do navegador para marcar / desmarcar o checkbox que determina a utilização de pagamento por meio de dois cartões. O estilo emula um switch, no formato comumente utilizado em aplicativos de celular, e qualquer clique nos labels associados ao input dispara a alteração do valor.

Nesta versão, fazemos todo o trabalho por meio de eventos e ações registrados em nossa própria classe Javascript, deixando de lado os padrões do navegador para associação entre label e input.