### PR TITLE
Inclusão de método para compatibilização com o OSC Inovarti

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Model/Carrier/Kiosk.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Model/Carrier/Kiosk.php
@@ -6,7 +6,9 @@
  * @author    Fillipe Dutra
  * @copyright 2021 Magenteiro
  */
-class RicardoMartins_PagSeguro_Model_Carrier_Kiosk extends Mage_Shipping_Model_Carrier_Abstract
+class RicardoMartins_PagSeguro_Model_Carrier_Kiosk
+    extends Mage_Shipping_Model_Carrier_Abstract
+    implements Mage_Shipping_Model_Carrier_Interface
 {
     protected $_code = "rm_pagseguro";
 
@@ -50,5 +52,25 @@ class RicardoMartins_PagSeguro_Model_Carrier_Kiosk extends Mage_Shipping_Model_C
     public function isAvailable()
     {
         return Mage::registry("rm_pagseguro_kiosk_order_creation_shipping_data") ? true : false;
+    }
+
+    /**
+     * Get allowed shipping methods
+     *
+     * @return array
+     */
+    public function getAllowedMethods()
+    {
+        return array();
+    }
+
+    /**
+     * Check if carrier has shipping tracking option available
+     *
+     * @return boolean
+     */
+    public function isTrackingAvailable()
+    {
+        return false;
     }
 }


### PR DESCRIPTION
O módulo de OSC da Inovarti conta com a presença de um método denominado getAllowedMethods em todas as formas de entrega. Este método não está no padrão da classe 'abstrata' do Magento, mas está definido na interface padrão.

Portanto pode ser interessante o inserirmos na forma de entrega emulada pela funcionalidade Kiosk. Caso contrário, a configuração do OSC não abre, mostrando uma exceção no código.