### PR TITLE
Tratamento para cancelamento de pedidos em revisão de pagamento

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Model/Abstract.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Model/Abstract.php
@@ -727,6 +727,13 @@ class RicardoMartins_PagSeguro_Model_Abstract extends Mage_Payment_Model_Method_
 
         if($orderCancellation->getShouldCancel())
         {
+            // checks if the order state is 'Pending Payment' and changes it
+            // so that the order can be cancelled
+            if ($order->getState() == Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW)
+            {
+                $order->setState(Mage_Sales_Model_Order::STATE_NEW);
+            }
+            
             $order->cancel();
         }
     }


### PR DESCRIPTION
Caso a transação da PagSeguro esteja 'Em Análise' (status 2), o state do pedido seja Payment Review e o pedido precisa ser cancelado pelo processamento de uma notificação, o status é alterado exatamente antes da ação de cancelamento para Novo.