### PR TITLE
Recálculo de parcelas erradas para pedidos com multiplos cartões

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
@@ -667,7 +667,7 @@ class RicardoMartins_PagSeguro_Helper_Data extends Mage_Core_Helper_Abstract
         $freeAmt = Mage::getStoreConfig(
             self::XML_PATH_PAYMENT_PAGSEGURO_CC_INSTALLMENT_FREE_INTEREST_MINIMUM_AMT
         );
-        if ($freeAmt === null) {
+        if (!$freeAmt) {
             return false;
         }
         

--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
@@ -667,7 +667,7 @@ class RicardoMartins_PagSeguro_Helper_Data extends Mage_Core_Helper_Abstract
         $freeAmt = Mage::getStoreConfig(
             self::XML_PATH_PAYMENT_PAGSEGURO_CC_INSTALLMENT_FREE_INTEREST_MINIMUM_AMT
         );
-        if (!$freeAmt) {
+        if ($freeAmt === null) {
             return false;
         }
         

--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Params.php
@@ -151,6 +151,9 @@ class RicardoMartins_PagSeguro_Helper_Params extends Mage_Core_Helper_Abstract
      */
     public function getCreditCardInstallmentsParams(Mage_Sales_Model_Order $order, $payment)
     {
+        $return = array();
+        $amount = $order->getGrandTotal();
+
         if($ccIdx = $payment->getData("_current_card_index"))
         {
             $cardData = $payment->getAdditionalInformation("cc" . $ccIdx);
@@ -162,8 +165,12 @@ class RicardoMartins_PagSeguro_Helper_Params extends Mage_Core_Helper_Abstract
                 $return = array
                 (
                     'installmentQuantity' => $cardData["installments_qty"],
-                    'installmentValue'    => $cardData["installments_value"],
+                    'installmentValue'    => number_format($cardData["installments_value"], 2, '.', ''),
                 );
+            }
+
+            if (isset($cardData["total"])) {
+                $amount = (float) $cardData["total"];
             }
         }
         else
@@ -180,8 +187,7 @@ class RicardoMartins_PagSeguro_Helper_Params extends Mage_Core_Helper_Abstract
             }
         }
 
-        $maxInstallmentsNoInterest = Mage::helper('ricardomartins_pagseguro')
-            ->getMaxInstallmentsNoInterest($order->getGrandTotal());
+        $maxInstallmentsNoInterest = Mage::helper('ricardomartins_pagseguro')->getMaxInstallmentsNoInterest($amount);
         
         if ($maxInstallmentsNoInterest !== false) {
             $return['noInterestInstallmentQuantity'] = $maxInstallmentsNoInterest;


### PR DESCRIPTION
Esta alteração permite que as parcelas sejam automaticamente recalculadas e a transação reenviada à PagSeguro em pagamentos com múltiplos cartões.