### PR TITLE
Adicionada personalização de mensagem de parcelas na página de produtos

### DIFF
--- a/app/code/community/RicardoMartins/PagSeguro/Block/Product/Installments.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Block/Product/Installments.php
@@ -60,4 +60,26 @@ class RicardoMartins_PagSeguro_Block_Product_Installments extends Mage_Core_Bloc
 
         return parent::_prepareLayout();
     }
+
+    /**
+     * Converte a messagem especificada em XML_PATH_PAYMENT_PAGSEGURO_CC_INSTALLMENT_PRODUCT_MESSAGE
+     * para exibição na página de produtos
+     */
+    public function _messageToHTML()
+    {
+        $variables = array(
+            "num_parcelas" => "installments", /** Número de parcelas. Ex.: 12 */
+            "valor_parcela" => "installment_value", /** Preço da parcela do produto */
+            "valor_total" => "installment_total" /** Preço total do produto (com o valor dos juros incluso, caso haja) */
+        );
+        $message = Mage::getStoreConfig(
+            RicardoMartins_PagSeguro_Helper_Data::XML_PATH_PAYMENT_PAGSEGURO_CC_INSTALLMENT_PRODUCT_MESSAGE
+        );
+
+        foreach ($variables as $variable => $id) {
+            $message = str_replace("{".$variable."}", "<span id='$id'></span>", $message);
+        }
+
+        return $message;
+    }
 }

--- a/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
+++ b/app/code/community/RicardoMartins/PagSeguro/Helper/Data.php
@@ -33,6 +33,8 @@ class RicardoMartins_PagSeguro_Helper_Data extends Mage_Core_Helper_Abstract
     const XML_PATH_PAYMENT_PAGSEGURO_KEY                = 'payment/pagseguropro/key';
     const XML_PATH_PAYMENT_PAGSEGURO_CC_FORCE_INSTALLMENTS = 'payment/rm_pagseguro_cc/force_installments_selection';
     const XML_PATH_PAYMENT_PAGSEGURO_CC_INSTALLMENT_LIMIT  = 'payment/rm_pagseguro_cc/installment_limit';
+    const XML_PATH_PAYMENT_PAGSEGURO_CC_INSTALLMENT_PRODUCT_MESSAGE =
+        'payment/rm_pagseguro_cc/installments_product_message';
     const XML_PATH_PAYMENT_PAGSEGURO_CC_INSTALLMENT_INTEREST_FREE_ONLY =
         'payment/rm_pagseguro_cc/installments_product_interestfree_only';
     const XML_PATH_PAYMENT_PAGSEGURO_CC_INSTALLMENT_FREE_INTEREST_MINIMUM_AMT =

--- a/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
+++ b/app/code/community/RicardoMartins/PagSeguro/etc/config.xml
@@ -185,6 +185,7 @@
                 <total_installments>0</total_installments>
                 <force_installments_selection>0</force_installments_selection>
                 <installments_product>0</installments_product>
+                <installments_product_message>Parcele em até {num_parcelas}x de R${valor_parcela} (Total R${valor_total}) com PagSeguro UOL.</installments_product_message>
                 <sort_order>1</sort_order>
             </rm_pagseguro_cc>
             <rm_pagseguro>

--- a/app/code/community/RicardoMartins/PagSeguro/etc/system.xml
+++ b/app/code/community/RicardoMartins/PagSeguro/etc/system.xml
@@ -458,9 +458,23 @@
                             <tooltip>Pode deixar sua página de produtos mais lenta.</tooltip>
                             <comment><![CDATA[É exibido o parcelamento máximo com base no cartão VISA, de acordo com suas configurações no PagSeguro. Saiba mais <a href="//pagsegurotransparente.zendesk.com/hc/pt-br/articles/360027562792" target="_blank">aqui</a>.]]></comment>
                         </installments_product>
+                        <installments_product_message>
+                            <label>Mensagem das parcelas na página de produto</label>
+                            <sort_order>130</sort_order>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <frontend_type>textarea</frontend_type>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <tooltip>Ex.: Parcele em até {num_parcelas}x de R${valor_parcela} (Total R${valor_total}) com PagSeguro UOL.</tooltip>
+                            <comment><![CDATA[A mensagem acima pode ser personalizada com as seguintes variáveis: <p class='note'><b>{num_parcelas}</b>: Número de parcelas. Ex.: 12</p><p class='note'><b>{valor_parcela}</b>: Preço da parcela do produto</p><p class='note'><b>{valor_total}</b>: Preço total do produto (com o valor dos juros incluso, caso haja)</p>]]></comment>
+                            <depends>
+                                <installments_product>1</installments_product>
+                            </depends>
+                        </installments_product_message>
                         <installments_product_interestfree_only>
                             <label>Exibir somente parcelas sem juros?</label>
-                            <sort_order>130</sort_order>
+                            <sort_order>140</sort_order>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <frontend_type>select</frontend_type>
                             <show_in_default>1</show_in_default>

--- a/app/design/frontend/base/default/template/ricardomartins_pagseguro/product/installments.phtml
+++ b/app/design/frontend/base/default/template/ricardomartins_pagseguro/product/installments.phtml
@@ -9,11 +9,12 @@ $_installmentsFreeOnly = (int)Mage::getStoreConfig(
     RicardoMartins_PagSeguro_Helper_Data::XML_PATH_PAYMENT_PAGSEGURO_CC_INSTALLMENT_INTEREST_FREE_ONLY
 );
 $_maxInstallmentNoInterest = $_helper->getMaxInstallmentsNoInterest($_price);
+
 ?>
 
 <div id="rmpagseguro_parcelas_box">
     <p id="rmpagseguro_parcelas_loading">Carregando parcelas...</p>
-    <p id="pseguro_parcelas" style="display: none;">Parcele em até <span id="installments"></span>x de R$<span id="installment_value"></span> (Total R$<span id="installment_total"></span>) com PagSeguro UOL.</p>
+    <p id="pseguro_parcelas" style="display: none;"><?= $this->_messageToHTML() ?></p>
 </div>
 
 <script type="text/javascript">
@@ -30,7 +31,7 @@ $_maxInstallmentNoInterest = $_helper->getMaxInstallmentsNoInterest($_price);
     })
     var updateInstallments = function() {
         var maxInstallmentNoInterest = "<?php echo $_maxInstallmentNoInterest?>";
-        
+
         PagSeguroDirectPayment.getInstallments({
             amount: <?php echo $_price?>,
             brand: 'visa',
@@ -50,16 +51,22 @@ $_maxInstallmentNoInterest = $_helper->getMaxInstallmentsNoInterest($_price);
                 if(maxInstallmentsConfig > 0 && maxInstallmentsConfig < responseVisa.length && maxInstallmentsConfig < installment.quantity){
                     installment = responseVisa[maxInstallmentsConfig - 1];
                 }
-                $('installments').innerHTML = installment.quantity.toString();
-                $('installment_value').innerHTML = installment.installmentAmount.toFixed(2).toString().replace('.', ',');
-                $('installment_total').innerHTML = installment.totalAmount.toFixed(2).toString().replace('.', ',');
-                if(installment.interestFree){
-                    $('installment_total').innerHTML += ' sem juros';
+                if ($('installments')) {
+                    $('installments').innerHTML = installment.quantity.toString();
+                }
+                if ($('installments_value')) {
+                    $('installment_value').innerHTML = installment.installmentAmount.toFixed(2).toString().replace('.', ',');
+                }
+                if ($('installments_total')) {
+                    $('installment_total').innerHTML = installment.totalAmount.toFixed(2).toString().replace('.', ',');
+                    if (installment.interestFree) {
+                        $('installment_total').innerHTML += ' sem juros';
+                    }
                 }
                 $('pseguro_parcelas').setStyle({display: ''});
                 $('rmpagseguro_parcelas_loading').setStyle({display: 'none'});
-            }
-        })
+                    }
+                })
     };
 // ]]>
 </script>


### PR DESCRIPTION
Permite personalizar a mensagem de parcelamento exibida na páginas de produtos de maneira mais prática via configurações do módulo.

**Tela de configurações**
![image](https://github.com/r-martins/PagSeguro-Magento-Transparente/assets/55641441/28bce2db-b724-49af-8ee3-d970e89e2a18)

**Página do produto**
![image](https://github.com/r-martins/PagSeguro-Magento-Transparente/assets/55641441/f42e507c-d3f2-4ea4-b9dd-7027c24c1d4c)
